### PR TITLE
Fix vercel.json: remove routes for correct static asset serving

### DIFF
--- a/react-frontend/vercel.json
+++ b/react-frontend/vercel.json
@@ -8,11 +8,5 @@
         "distDir": "dist"
       }
     }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
   ]
 } 


### PR DESCRIPTION
Fix vercel.json: remove routes for correct static asset serving